### PR TITLE
sql/analyzer: fix analysis of expressions.

### DIFF
--- a/engine_test.go
+++ b/engine_test.go
@@ -11,21 +11,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+
 func TestEngine_Query(t *testing.T) {
+	e := newEngine(t)
+	testQuery(t, e,
+		"SELECT i FROM mytable;",
+		[]sql.Row{
+			sql.NewMemoryRow(int64(1)),
+			sql.NewMemoryRow(int64(2)),
+			sql.NewMemoryRow(int64(3)),
+		},
+	)
+
+	testQuery(t, e,
+		"SELECT i FROM mytable WHERE i = 2;",
+		[]sql.Row{
+			sql.NewMemoryRow(int64(2)),
+		},
+	)
+}
+
+
+func testQuery(t *testing.T, e *gitql.Engine, q string, r []sql.Row) {
 	assert := require.New(t)
 
-	table := mem.NewTable("mytable", sql.Schema{{"i", sql.Integer}})
-	assert.Nil(table.Insert(int32(1)))
-	assert.Nil(table.Insert(int32(2)))
-	assert.Nil(table.Insert(int32(3)))
-
-	db := mem.NewDatabase("mydb")
-	db.AddTable("mytable", table)
-
-	e := gitql.New()
-	e.AddDatabase(db)
-
-	q := "SELECT i FROM mytable;"
 	schema, iter, err := e.Query(q)
 	assert.Nil(err)
 	assert.NotNil(iter)
@@ -42,8 +51,24 @@ func TestEngine_Query(t *testing.T) {
 		}
 		results = append(results, el)
 	}
-	assert.Len(results, 3)
-	assert.Equal(sql.NewMemoryRow(int32(1)), results[0])
-	assert.Equal(sql.NewMemoryRow(int32(2)), results[1])
-	assert.Equal(sql.NewMemoryRow(int32(3)), results[2])
+
+	assert.Len(results, len(r))
+	assert.Equal(results, r)
+}
+
+func newEngine(t *testing.T) *gitql.Engine {
+	assert := require.New(t)
+
+	table := mem.NewTable("mytable", sql.Schema{{"i", sql.BigInteger}})
+	assert.Nil(table.Insert(int64(1)))
+	assert.Nil(table.Insert(int64(2)))
+	assert.Nil(table.Insert(int64(3)))
+
+	db := mem.NewDatabase("mydb")
+	db.AddTable("mytable", table)
+
+	e := gitql.New()
+	e.AddDatabase(db)
+
+	return e
 }

--- a/sql/analyzer/analyzer_test.go
+++ b/sql/analyzer/analyzer_test.go
@@ -49,6 +49,30 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	)
 	assert.Nil(err)
 	assert.Equal(expected, analyzed)
+
+	notAnalyzed = plan.NewProject(
+		[]sql.Expression{expression.NewUnresolvedColumn("i")},
+		plan.NewFilter(
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("i"),
+				expression.NewLiteral(int32(1), sql.Integer),
+			),
+			plan.NewUnresolvedRelation("mytable"),
+		),
+	)
+	analyzed, err = a.Analyze(notAnalyzed)
+	expected = plan.NewProject(
+		[]sql.Expression{expression.NewGetField(0, sql.Integer, "i")},
+		plan.NewFilter(
+			expression.NewEquals(
+				expression.NewGetField(0, sql.Integer, "i"),
+				expression.NewLiteral(int32(1), sql.Integer),
+			),
+			table,
+		),
+	)
+	assert.Nil(err)
+	assert.Equal(expected, analyzed)
 }
 
 func TestAnalyzer_Analyze_MaxIterations(t *testing.T) {

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -38,9 +38,6 @@ func resolveColumns(a *Analyzer, n sql.Node) sql.Node {
 	}
 
 	child := n.Children()[0]
-	if !child.Resolved() {
-		return n
-	}
 
 	colMap := map[string]*expression.GetField{}
 	for idx, child := range child.Schema() {


### PR DESCRIPTION
Expressions for children nodes were never resolved.