### PR TITLE
sql/parse: add support for expression aliases.

### DIFF
--- a/cmd/gitql/query.go
+++ b/cmd/gitql/query.go
@@ -95,6 +95,7 @@ func (c *CmdQuery) printQuery(schema sql.Schema, iter sql.RowIter) {
 	w := tablewriter.NewWriter(os.Stdout)
 	headers := []string{}
 	for _, f := range schema {
+		fmt.Printf("HEADER: %s\n", f.Name)
 		headers = append(headers, f.Name)
 	}
 	w.SetHeader(headers)

--- a/sql/analyzer/analyzer_test.go
+++ b/sql/analyzer/analyzer_test.go
@@ -51,6 +51,28 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	assert.Equal(expected, analyzed)
 
 	notAnalyzed = plan.NewProject(
+		[]sql.Expression{
+			expression.NewAlias(
+				expression.NewUnresolvedColumn("i"),
+				"foo",
+			),
+		},
+		plan.NewUnresolvedTable("mytable"),
+	)
+	analyzed, err = a.Analyze(notAnalyzed)
+	expected = plan.NewProject(
+		[]sql.Expression{
+			expression.NewAlias(
+				expression.NewGetField(0, sql.Integer, "i"),
+				"foo",
+			),
+		},
+		table,
+	)
+	assert.Nil(err)
+	assert.Equal(expected, analyzed)
+
+	notAnalyzed = plan.NewProject(
 		[]sql.Expression{expression.NewUnresolvedColumn("i")},
 		plan.NewFilter(
 			expression.NewEquals(

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -18,6 +18,15 @@ var fixtures = map[string]sql.Node{
 		},
 		plan.NewUnresolvedTable("foo"),
 	),
+	`SELECT foo AS bar FROM foo;`: plan.NewProject(
+		[]sql.Expression{
+			expression.NewAlias(
+				expression.NewUnresolvedColumn("foo"),
+				"bar",
+			),
+		},
+		plan.NewUnresolvedTable("foo"),
+	),
 	`SELECT foo, bar FROM foo WHERE foo = bar;`: plan.NewProject(
 		[]sql.Expression{
 			expression.NewUnresolvedColumn("foo"),

--- a/sql/plan/project.go
+++ b/sql/plan/project.go
@@ -7,29 +7,25 @@ import (
 type Project struct {
 	UnaryNode
 	expressions []sql.Expression
-	schema      sql.Schema
 }
 
 func NewProject(expressions []sql.Expression, child sql.Node) *Project {
-	schema := sql.Schema{}
-	childSchema := child.Schema()
-	for _, expr := range expressions {
-		for _, field := range childSchema {
-			if expr.Name() == field.Name {
-				schema = append(schema, field)
-				break
-			}
-		}
-	}
 	return &Project{
 		UnaryNode:   UnaryNode{child},
 		expressions: expressions,
-		schema:      schema,
 	}
 }
 
 func (p *Project) Schema() sql.Schema {
-	return p.schema
+	var s sql.Schema
+	for _, e := range p.expressions {
+		f := sql.Field{
+			Name: e.Name(),
+			Type: e.Type(),
+		}
+		s = append(s, f)
+	}
+	return s
 }
 
 func (p *Project) Resolved() bool {

--- a/sql/plan/project_test.go
+++ b/sql/plan/project_test.go
@@ -46,5 +46,16 @@ func TestProject(t *testing.T) {
 	require.Nil(row)
 
 	p = NewProject(nil, child)
-	require.Equal(0, len(p.schema))
+	require.Equal(0, len(p.Schema()))
+
+	p = NewProject([]sql.Expression{
+		expression.NewAlias(
+			expression.NewGetField(1, sql.String, "col2"),
+			"foo",
+		),
+	}, child)
+	schema = sql.Schema{
+		sql.Field{"foo", sql.String},
+	}
+	require.Equal(schema, p.Schema())
 }


### PR DESCRIPTION
* Add alias parsing support.
* Fix plan.Project so that it calculates schema properly
  when child schema differs in names.