### PR TITLE
sql: support parsing and executing CROSS JOIN

### DIFF
--- a/sql/analyzer/analyzer_test.go
+++ b/sql/analyzer/analyzer_test.go
@@ -17,8 +17,10 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	assert := require.New(t)
 
 	table := mem.NewTable("mytable", sql.Schema{{"i", sql.Integer}})
+	table2 := mem.NewTable("mytable2", sql.Schema{{"i2", sql.Integer}})
 	db := mem.NewDatabase("mydb")
 	db.AddTable("mytable", table)
+	db.AddTable("mytable2", table2)
 
 	catalog := &sql.Catalog{Databases: []sql.Database{db}}
 	a := analyzer.New(catalog)
@@ -92,6 +94,27 @@ func TestAnalyzer_Analyze(t *testing.T) {
 			),
 			table,
 		),
+	)
+	assert.Nil(err)
+	assert.Equal(expected, analyzed)
+
+	notAnalyzed = plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedColumn("i"),
+			expression.NewUnresolvedColumn("i2"),
+		},
+		plan.NewCrossJoin(
+			plan.NewUnresolvedTable("mytable"),
+			plan.NewUnresolvedTable("mytable2"),
+		),
+	)
+	analyzed, err = a.Analyze(notAnalyzed)
+	expected = plan.NewProject(
+		[]sql.Expression{
+			expression.NewGetField(0, sql.Integer, "i"),
+			expression.NewGetField(1, sql.Integer, "i2"),
+		},
+		plan.NewCrossJoin(table, table2),
 	)
 	assert.Nil(err)
 	assert.Equal(expected, analyzed)

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -39,6 +39,7 @@ func resolveColumns(a *Analyzer, n sql.Node) sql.Node {
 
 	child := n.Children()[0]
 
+	//TODO: Fail when there is no unambiguous resolution.
 	colMap := map[string]*expression.GetField{}
 	for idx, child := range child.Schema() {
 		colMap[child.Name] = expression.NewGetField(idx, child.Type, child.Name)

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -117,6 +117,16 @@ var fixtures = map[string]sql.Node{
 			),
 		),
 	),
+	`SELECT foo, bar FROM t1, t2;`: plan.NewProject(
+		[]sql.Expression{
+			expression.NewUnresolvedColumn("foo"),
+			expression.NewUnresolvedColumn("bar"),
+		},
+		plan.NewCrossJoin(
+			plan.NewUnresolvedTable("t1"),
+			plan.NewUnresolvedTable("t2"),
+		),
+	),
 }
 
 func TestParse(t *testing.T) {


### PR DESCRIPTION
* added support to parse CROSS JOIN.
* improved CROSS JOIN code.
* added tests for CROSS JOIN with one empty side.
* added tests for CROSS JOIN parsing and analysis.